### PR TITLE
Implement retry mechanism for Anthropic models

### DIFF
--- a/freeact/model/base.py
+++ b/freeact/model/base.py
@@ -21,12 +21,18 @@ class CodeActModelResponse(ABC):
     def code(self) -> str | None: ...
 
 
+@dataclass
+class StreamRetry:
+    cause: str
+    retry_wait_time: float
+
+
 class CodeActModelTurn(ABC):
     @abstractmethod
     async def response(self) -> CodeActModelResponse: ...
 
     @abstractmethod
-    def stream(self) -> AsyncIterator[str]: ...
+    def stream(self, emit_retry: bool = False) -> AsyncIterator[str | StreamRetry]: ...
 
 
 class CodeActModel(ABC):

--- a/freeact/model/claude/retry.py
+++ b/freeact/model/claude/retry.py
@@ -1,0 +1,110 @@
+import asyncio
+import sys
+from abc import ABC, abstractmethod
+from typing import AsyncIterator, Callable
+
+from anthropic import APIStatusError
+
+from freeact.logger import Logger
+from freeact.model.base import StreamRetry
+
+_MAX_WAIT = sys.maxsize / 2
+
+
+class WaitStrategy(ABC):
+    @abstractmethod
+    def compute_wait_time(self, retry_attempt: int) -> float: ...
+
+
+class WaitExponential(WaitStrategy):
+    """Wait strategy that applies exponential backoff.
+
+    Args:
+        multiplier (float, optional): Value to multiply the exponential factor by.
+            Defaults to 1.
+        max (float, optional): Maximum wait time allowed. Defaults to system's maxsize/2.
+        exp_base (float, optional): Base for exponential calculation. Defaults to 2.
+        min (float, optional): Minimum wait time allowed. Defaults to 0.
+    """
+
+    def __init__(
+        self,
+        multiplier: float = 1,
+        max: float = _MAX_WAIT,
+        exp_base: float = 2,
+        min: float = 0,
+    ) -> None:
+        self._multiplier = multiplier
+        self._min = min
+        self._max = max
+        self._exp_base = exp_base
+
+    def compute_wait_time(self, retry_attempt: int) -> float:
+        try:
+            exp = self._exp_base ** (retry_attempt - 1)
+            result = self._multiplier * exp
+        except OverflowError:
+            return self._max
+        return max(max(0, self._min), min(result, self._max))
+
+
+async def retry(
+    stream_func: Callable[[], AsyncIterator],
+    logger: Logger,
+    retry_max_attempts: int,
+    retry_wait_strategy: WaitStrategy,
+) -> AsyncIterator:
+    from freeact.model.claude.model import ClaudeResponse
+
+    retry_attempt = 0
+    while True:
+        try:
+            async for elem in stream_func():
+                match elem:
+                    case str():
+                        yield elem
+                    case ClaudeResponse() as res:
+                        yield res
+                        return
+        except APIStatusError as err:
+            async with logger.context("error"):
+                message = f"APIStatusError occurred:\nStatus Code: {err.status_code}\nMessage: {err.message}\nBody: {err.body}\nHeaders: {err.response.headers}"
+                await logger.log(message, metadata={"message": err.message})
+
+            retry_attempt += 1
+            if retry_attempt > retry_max_attempts:
+                raise RuntimeError(f"Maximum retry attempts reached (retry_max_attempts={retry_max_attempts}).", err)
+
+            is_retryable, retry_wait_time = _get_retry_info(retry_wait_strategy, err, retry_attempt)
+            if not is_retryable:
+                raise err
+
+            yield StreamRetry(cause=str(err), retry_wait_time=retry_wait_time)  # type: ignore
+            await asyncio.sleep(retry_wait_time)  # type: ignore
+
+
+def _get_retry_info(wait_strategy: WaitStrategy, error: Exception, retry_attempt: int) -> tuple[bool, float | None]:
+    match error:
+        case APIStatusError(body=body, response=res):
+            if not body or not isinstance(body, dict) or body.get("type") != "error" or "type" not in body["error"]:
+                # Body is not a valid JSON object or is not a valid error body. For more details, see:
+                # * https://docs.anthropic.com/en/api/messages-streaming#error-events
+                # * https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/_streaming.py#L192
+                return False, None
+
+            error_type = body["error"]["type"]
+
+            if error_type in ["api_error", "overloaded_error"]:
+                return True, wait_strategy.compute_wait_time(retry_attempt)
+
+            if error_type == "rate_limit_error":
+                try:
+                    return True, float(
+                        res.headers.get("retry-after")
+                    )  # see https://docs.anthropic.com/en/api/rate-limits#response-headers
+                except (ValueError, TypeError):
+                    return True, wait_strategy.compute_wait_time(retry_attempt)
+
+            return False, None
+        case _:
+            return False, None

--- a/freeact/model/gemini/model.py
+++ b/freeact/model/gemini/model.py
@@ -6,7 +6,7 @@ from typing import AsyncIterator, List
 from google import genai
 from google.genai.live import AsyncSession
 
-from freeact.model.base import CodeActModel, CodeActModelResponse, CodeActModelTurn
+from freeact.model.base import CodeActModel, CodeActModelResponse, CodeActModelTurn, StreamRetry
 from freeact.model.gemini.prompt import EXECUTION_ERROR_TEMPLATE, EXECUTION_OUTPUT_TEMPLATE, SYSTEM_TEMPLATE
 from freeact.skills import SkillInfo
 
@@ -45,7 +45,7 @@ class GeminiTurn(CodeActModelTurn):
             pass
         return self._response  # type: ignore
 
-    async def stream(self) -> AsyncIterator[str]:
+    async def stream(self, emit_retry: bool = False) -> AsyncIterator[str | StreamRetry]:
         async for elem in self._iter:
             match elem:
                 case str():

--- a/tests/unit/model/claude/test_retry.py
+++ b/tests/unit/model/claude/test_retry.py
@@ -1,0 +1,323 @@
+from typing import AsyncIterator, Callable
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from anthropic import APIStatusError
+
+from freeact.logger import Logger
+from freeact.model.base import StreamRetry
+from freeact.model.claude.model import ClaudeResponse
+from freeact.model.claude.retry import (
+    WaitExponential,
+    WaitStrategy,
+    _get_retry_info,
+    retry,
+)
+
+
+@pytest.fixture
+def logger():
+    return AsyncMock(spec=Logger)
+
+
+def assert_stream_results(
+    results: list[str | StreamRetry | ClaudeResponse],
+    expected_results: list[str | StreamRetry | ClaudeResponse],
+):
+    assert len(results) == len(expected_results)
+    for result, expected in zip(results, expected_results):
+        if isinstance(expected, StreamRetry):
+            assert isinstance(result, StreamRetry)
+        else:
+            assert result == expected
+
+
+def create_api_status_error_with_body(body: str | dict | None, headers: dict[str, str] | None = None) -> APIStatusError:
+    response = httpx.Response(status_code=200, headers=headers)
+    response.request = httpx.Request("GET", "https://example.com")
+
+    return APIStatusError(
+        message="API Error",
+        body=body,
+        response=response,
+    )
+
+
+def create_failing_stream(num_failures: int, error_type: str):
+    call_count = 0
+
+    async def failing_stream():
+        nonlocal call_count
+
+        yield "part-1"
+
+        call_count += 1
+        if call_count <= num_failures:
+            raise create_api_status_error(error_type)
+
+        yield ClaudeResponse(text="part-1", is_error=False)
+
+    return failing_stream
+
+
+def create_api_status_error(error_type: str, headers: dict[str, str] | None = None) -> APIStatusError:
+    return create_api_status_error_with_body(
+        body={
+            "type": "error",
+            "error": {"type": error_type, "message": "error message"},
+        },
+        headers=headers,
+    )
+
+
+async def consume_stream(
+    stream_fn: Callable[[], AsyncIterator[str | StreamRetry | ClaudeResponse]],
+    logger,
+    retry_max_attempts: int,
+    retry_wait_strategy: WaitStrategy,
+):
+    results = []
+    async for item in retry(
+        stream_fn,
+        logger,
+        retry_max_attempts=retry_max_attempts,
+        retry_wait_strategy=retry_wait_strategy,
+    ):
+        results.append(item)
+    return results
+
+
+@pytest.mark.asyncio
+async def test_retry_on_successful_stream(logger):
+    async def stream_func():
+        yield "part-1"
+        yield "part-2"
+        yield ClaudeResponse(text="part-1 part-2", is_error=False)
+
+    results = await consume_stream(
+        stream_func,
+        logger,
+        retry_max_attempts=3,
+        retry_wait_strategy=WaitExponential(),
+    )
+
+    assert_stream_results(
+        results,
+        [
+            "part-1",
+            "part-2",
+            ClaudeResponse(text="part-1 part-2", is_error=False),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_type",
+    [
+        "api_error",
+        "rate_limit_error",
+        "overloaded_error",
+    ],
+)
+async def test_single_retry_on_retryable_api_error(logger, error_type):
+    stream_fn = create_failing_stream(
+        num_failures=1,
+        error_type=error_type,
+    )
+    retry_max_attempts = 3
+
+    results = await consume_stream(
+        stream_fn,
+        logger,
+        retry_max_attempts=retry_max_attempts,
+        retry_wait_strategy=WaitExponential(multiplier=0.1),
+    )
+
+    assert_stream_results(
+        results,
+        [
+            "part-1",
+            StreamRetry(cause=error_type, retry_wait_time=0.1),
+            "part-1",
+            ClaudeResponse(text="part-1", is_error=False),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_type",
+    [
+        "api_error",
+        "rate_limit_error",
+        "overloaded_error",
+    ],
+)
+async def test_multiple_retries_on_retryable_api_error(logger, error_type):
+    stream_fn = create_failing_stream(
+        num_failures=2,
+        error_type=error_type,
+    )
+    retry_max_attempts = 3
+
+    results = await consume_stream(
+        stream_fn,
+        logger,
+        retry_max_attempts=retry_max_attempts,
+        retry_wait_strategy=WaitExponential(multiplier=0.1),
+    )
+
+    assert_stream_results(
+        results,
+        [
+            "part-1",
+            StreamRetry(cause=error_type, retry_wait_time=0.1),
+            "part-1",
+            StreamRetry(cause=error_type, retry_wait_time=0.1),
+            "part-1",
+            ClaudeResponse(text="part-1", is_error=False),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_type",
+    [
+        "invalid_request_error",
+        "authentication_error",
+        "permission_error",
+        "not_found_error",
+        "request_too_large",
+    ],
+)
+async def test_retry_on_non_retryable_api_error(logger, error_type):
+    stream_fn = create_failing_stream(
+        num_failures=1,
+        error_type=error_type,
+    )
+    retry_max_attempts = 3
+
+    with pytest.raises(APIStatusError):
+        await consume_stream(
+            stream_fn,
+            logger,
+            retry_max_attempts=retry_max_attempts,
+            retry_wait_strategy=WaitExponential(multiplier=0.1),
+        )
+
+
+@pytest.mark.asyncio
+async def test_stop_retry_on_max_attempts(logger):
+    stream_fn = create_failing_stream(num_failures=5, error_type="overloaded_error")
+    retry_max_attempts = 3
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await consume_stream(
+            stream_fn,
+            logger,
+            retry_max_attempts=retry_max_attempts,
+            retry_wait_strategy=WaitExponential(multiplier=0.1),
+        )
+        assert "Maximum retry attempts reached" in str(exc_info.value)
+
+
+def test_get_retry_info_on_api_error():
+    should_retry, wait_time = _get_retry_info(
+        error=create_api_status_error("api_error"),
+        wait_strategy=WaitExponential(multiplier=0.5),
+        retry_attempt=1,
+    )
+
+    assert should_retry is True
+    assert wait_time == 0.5
+
+
+def test_get_retry_info_on_overloaded_error():
+    should_retry, wait_time = _get_retry_info(
+        error=create_api_status_error("overloaded_error"),
+        wait_strategy=WaitExponential(multiplier=0.5),
+        retry_attempt=1,
+    )
+
+    assert should_retry is True
+    assert wait_time == 0.5
+
+
+def test_get_retry_info_on_rate_limit_error_without_retry_after():
+    should_retry, wait_time = _get_retry_info(
+        error=create_api_status_error("rate_limit_error"),
+        wait_strategy=WaitExponential(multiplier=0.5),
+        retry_attempt=1,
+    )
+
+    assert should_retry is True
+    assert wait_time == 0.5
+
+
+def test_get_retry_info_on_rate_limit_error_with_retry_after():
+    should_retry, wait_time = _get_retry_info(
+        error=create_api_status_error("rate_limit_error", headers={"retry-after": "30"}),
+        wait_strategy=WaitExponential(multiplier=0.5),
+        retry_attempt=1,
+    )
+
+    assert should_retry is True
+    assert wait_time == 30
+
+
+def test_get_retry_info_on_non_retryable_api_error():
+    should_retry, wait_time = _get_retry_info(
+        error=create_api_status_error("invalid_request_error"),
+        wait_strategy=WaitExponential(multiplier=0.5),
+        retry_attempt=1,
+    )
+
+    assert should_retry is False
+    assert wait_time is None
+
+
+def test_get_retry_info_on_non_api_error():
+    should_retry, wait_time = _get_retry_info(
+        error=RuntimeError("Non-API error"),
+        wait_strategy=WaitExponential(multiplier=0.5),
+        retry_attempt=1,
+    )
+
+    assert should_retry is False
+    assert wait_time is None
+
+
+def test_get_retry_info_on_api_error_with_non_json_body():
+    should_retry, wait_time = _get_retry_info(
+        error=create_api_status_error_with_body(body="not a valid JSON object"),
+        wait_strategy=WaitExponential(multiplier=0.5),
+        retry_attempt=1,
+    )
+
+    assert should_retry is False
+    assert wait_time is None
+
+
+def test_get_retry_info_on_api_error_with_empty_body():
+    should_retry, wait_time = _get_retry_info(
+        error=create_api_status_error_with_body(body=None),
+        wait_strategy=WaitExponential(multiplier=0.5),
+        retry_attempt=1,
+    )
+
+    assert should_retry is False
+    assert wait_time is None
+
+
+def test_get_retry_info_on_non_error_api_result():
+    should_retry, wait_time = _get_retry_info(
+        error=create_api_status_error_with_body(body={"type": "other"}),
+        wait_strategy=WaitExponential(multiplier=0.5),
+        retry_attempt=1,
+    )
+
+    assert should_retry is False
+    assert wait_time is None

--- a/tests/unit/model/claude/test_retry_wait_strategy.py
+++ b/tests/unit/model/claude/test_retry_wait_strategy.py
@@ -1,0 +1,31 @@
+from freeact.model.claude.retry import WaitExponential
+
+
+def test_basic_exponential_backoff():
+    strategy = WaitExponential(multiplier=1)
+    assert strategy.compute_wait_time(1) == 1  # 1 * 2^0
+    assert strategy.compute_wait_time(2) == 2  # 1 * 2^1
+    assert strategy.compute_wait_time(3) == 4  # 1 * 2^2
+    assert strategy.compute_wait_time(4) == 8  # 1 * 2^3
+
+
+def test_with_multiplier():
+    strategy = WaitExponential(multiplier=0.5)
+    assert strategy.compute_wait_time(1) == 0.5  # 0.5 * 2^0
+    assert strategy.compute_wait_time(2) == 1.0  # 0.5 * 2^1
+    assert strategy.compute_wait_time(3) == 2.0  # 0.5 * 2^2
+
+
+def test_with_min_max():
+    strategy = WaitExponential(multiplier=1, min=2, max=6)
+    assert strategy.compute_wait_time(1) == 2  # min bound
+    assert strategy.compute_wait_time(2) == 2
+    assert strategy.compute_wait_time(3) == 4
+    assert strategy.compute_wait_time(4) == 6  # max bound
+    assert strategy.compute_wait_time(5) == 6  # max bound
+
+
+def test_overflow_returns_max():
+    strategy = WaitExponential(multiplier=1, max=100)
+    # Using a very large retry attempt that would cause overflow
+    assert strategy.compute_wait_time(1000) == 100

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1,6 +1,7 @@
 from typing import AsyncIterator, List
 
 from freeact.agent import CodeActModel, CodeActModelResponse, CodeActModelTurn
+from freeact.model.base import StreamRetry
 
 
 class MockModelResponse(CodeActModelResponse):
@@ -33,7 +34,7 @@ class MockModelTurn(CodeActModelTurn):
     async def response(self) -> CodeActModelResponse:
         return self.response_obj
 
-    async def stream(self) -> AsyncIterator[str]:
+    async def stream(self, emit_retry: bool = False) -> AsyncIterator[str | StreamRetry]:
         for chunk in self.stream_chunks:
             yield chunk
 


### PR DESCRIPTION
* Implement retry mechanism for transient errors returned by the Anthropic streaming API
* Retry `rate_limit_error`, `api_error` and `overloaded_error`
* Optionally emit a `StreamRetry` event to the client