### PR TITLE
Refactor environment variables in integration test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-      QWEN_CODER_API_KEY: ${{ secrets.TEST_QWEN_CODER_API_KEY }}
-      QWEN_CODER_BASE_URL: ${{ secrets.TEST_QWEN_CODER_BASE_URL }}
-      QWEN_CODER_MODEL_NAME: ${{ secrets.TEST_QWEN_CODER_MODEL_NAME }}
+      QWEN_API_KEY: ${{ secrets.TEST_QWEN_CODER_API_KEY }}
+      QWEN_BASE_URL: ${{ secrets.TEST_QWEN_CODER_BASE_URL }}
+      QWEN_MODEL_NAME: ${{ secrets.TEST_QWEN_CODER_MODEL_NAME }}
 
     steps:
       - uses: actions/checkout@v4

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -43,10 +43,10 @@ ANTHROPIC_API_KEY=...
 # Required for generative Google Search via Gemini 2
 GOOGLE_API_KEY=...
 
-# Required to run integration tests for QwenCoder via HuggingFace API
-QWEN_CODER_MODEL_NAME=Qwen/Qwen2.5-Coder-32B-Instruct
-QWEN_CODER_BASE_URL=https://api-inference.huggingface.co/v1/
-QWEN_CODER_API_KEY=...
+# Required to run integration tests using Qwen models via HuggingFace API
+QWEN_MODEL_NAME=Qwen/Qwen2.5-Coder-32B-Instruct
+QWEN_BASE_URL=https://api-inference.huggingface.co/v1/
+QWEN_API_KEY=...
 ```
 
 Enforce coding conventions (done automatically by pre-commit hooks):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -28,9 +28,5 @@ def claude(logger):
 
 
 @pytest.fixture
-def qwen_coder_config():
-    return {
-        "model_name": os.getenv("QWEN_CODER_MODEL_NAME"),
-        "api_key": os.getenv("QWEN_CODER_API_KEY"),
-        "base_url": os.getenv("QWEN_CODER_BASE_URL"),
-    }
+def qwen_model_name():
+    return os.getenv("QWEN_MODEL_NAME")

--- a/tests/integration/test_agent.py
+++ b/tests/integration/test_agent.py
@@ -66,13 +66,11 @@ def gemini(skill_sources, request):
 
 
 @pytest.fixture
-def qwen_coder(qwen_coder_config, skill_sources, request):
+def qwen_coder(qwen_model_name, skill_sources, request):
     use_skill_sources = "skill_sources" in request.node.fixturenames  # check if the test requires skill sources
 
     return QwenCoder(
-        model_name=qwen_coder_config["model_name"],
-        api_key=qwen_coder_config["api_key"],
-        base_url=qwen_coder_config["base_url"],
+        model_name=qwen_model_name,
         skill_sources=skill_sources if use_skill_sources else None,
     )
 

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -32,13 +32,11 @@ def gemini(skill_sources, request):
 
 
 @pytest.fixture
-def qwen_coder(qwen_coder_config, skill_sources, request):
+def qwen_coder(qwen_model_name, skill_sources, request):
     use_skill_sources = "skill_sources" in request.node.fixturenames  # check if the test requires skill sources
 
     return QwenCoder(
-        model_name=qwen_coder_config["model_name"],
-        api_key=qwen_coder_config["api_key"],
-        base_url=qwen_coder_config["base_url"],
+        model_name=qwen_model_name,
         skill_sources=skill_sources if use_skill_sources else None,
     )
 


### PR DESCRIPTION
* Use default environment variables for `QwenCoder` model in integration test