### PR TITLE
Clear input field on Escape when agent is idle

### DIFF
--- a/freeact/terminal/app.py
+++ b/freeact/terminal/app.py
@@ -498,6 +498,8 @@ class TerminalApp(App[None]):
         hints = results.first(Static)
         if self._turn_in_progress:
             hints.update("ctrl+q: quit  esc: interrupt")
+        elif self.query_one("#prompt-input", PromptInput).text:
+            hints.update("ctrl+q: quit  esc: clear")
         else:
             hints.update("ctrl+q: quit")
 
@@ -985,6 +987,7 @@ class TerminalApp(App[None]):
     def on_text_area_changed(self, event: "textual.widgets.TextArea.Changed") -> None:  # type: ignore[name-defined]  # noqa: F821
         if event.text_area.id != "prompt-input":
             return
+        self._update_input_hints()
         slash_ctx = _find_slash_command_context(event.text_area.text, event.text_area.cursor_location)
         if slash_ctx is not None and self._skills_metadata:
             self._open_skill_picker(slash_ctx)

--- a/freeact/terminal/widgets.py
+++ b/freeact/terminal/widgets.py
@@ -77,6 +77,13 @@ class PromptInput(TextArea):
         )
 
     async def _on_key(self, event: "textual.events.Key") -> None:  # type: ignore[name-defined]  # noqa: F821
+        if event.key == "escape":
+            if self.text:
+                event.prevent_default()
+                event.stop()
+                self.clear()
+            return
+
         if event.key in ("ctrl+j", "newline"):
             event.prevent_default()
             event.stop()


### PR DESCRIPTION
## Summary
- Pressing Escape while the input field has focus and the agent is idle clears the input text
- Input hints dynamically show `esc: clear` only when the input contains text
- During processing, Escape continues to interrupt as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)