### PR TITLE
Enable text selection for all terminal widgets

### DIFF
--- a/docs/internal/architecture/constraints/widgets.md
+++ b/docs/internal/architecture/constraints/widgets.md
@@ -22,3 +22,11 @@ Tool-call factories (code action, tool call, file read/write/edit, subagent task
 Title formatting uses `_titled(title, agent_id)` for consistent prefixing.
 
 When adding a new widget type, follow this pattern: free function (not a method), returns `Collapsible` or `tuple[Collapsible, Widget]`, accepts `agent_id` for title formatting. For tool-call widgets, include a `tool-trace-container` for nested results.
+
+## Text Selection
+
+- Never pass `Syntax` directly to `Static`. Use `Static(_syntax_to_content(syntax))` or `Static(text, markup=False)`.
+- `RichLog` does not support selection. `finalize_exec_output` replaces it with a `Static` after streaming completes.
+- Do not set `line_numbers=True` on `Syntax` used with `_syntax_to_content`.
+
+See [terminal.md](../terminal.md#text-selection) for background on why these constraints exist.

--- a/docs/internal/architecture/terminal.md
+++ b/docs/internal/architecture/terminal.md
@@ -52,6 +52,13 @@ Read this first, then follow code references for details.
 - Clipboard model: OS clipboard is source of truth; Textual local clipboard is fallback cache.
 - Approval decisions can come from `ApprovalBar` or app-level hotkeys (`enter`, `y`, `n`, `a`, `s`).
 
+## Text Selection
+
+Textual's selection requires widgets to render via `Content` (or `Text`). Two cases need handling:
+
+- Rich `Syntax` produces a `RichVisual`, which bypasses selection. `_syntax_to_content()` converts `Syntax` to `Content`, stripping `bgcolor` from token spans so the `screen--selection` highlight can show through.
+- `RichLog` streams chunks during execution but does not support selection. `finalize_exec_output` replaces the `RichLog` with a plain `Static` after streaming completes.
+
 ## Testing
 
 - Terminal test patterns live in `tests/AGENTS.md`.

--- a/freeact/terminal/app.py
+++ b/freeact/terminal/app.py
@@ -777,8 +777,7 @@ class TerminalApp(App[None]):
             conversation,
             turn_state,
         )
-        rewrite_text = text if (truncated or created_now) else None
-        finalize_exec_output(exec_state.log, rewrite_text, images)
+        await finalize_exec_output(exec_state.log, text, images)
         if self._config.collapse_exec_output_on_complete:
             self._collapse_state.set_configured(exec_state.box, collapsed=True)
         self._schedule_scroll_conversation_to_bottom()

--- a/freeact/terminal/widgets.py
+++ b/freeact/terminal/widgets.py
@@ -4,10 +4,13 @@ from pathlib import Path
 from typing import Any
 
 from rich.segment import Segment
+from rich.style import Style as RichStyle
 from rich.syntax import Syntax
+from rich.text import Span as RichSpan
 from textual._ansi_sequences import ANSI_SEQUENCES_KEYS
 from textual.binding import Binding
 from textual.containers import Vertical
+from textual.content import Content
 from textual.keys import Keys
 from textual.message import Message
 from textual.strip import Strip
@@ -200,6 +203,32 @@ class ApprovalBar(Static):
         return super().check_action(action, parameters)
 
 
+def _syntax_to_content(syntax: Syntax) -> Content:
+    """Convert a Rich Syntax renderable to a Textual Content object.
+
+    Textual's selection API only works with `Text` or `Content` visuals.
+    Rich `Syntax` produces a `RichVisual` that bypasses selection entirely.
+    This converts Syntax to Content, preserving foreground syntax colors
+    while stripping explicit backgrounds from token spans. Without this,
+    Syntax backgrounds override the selection highlight style.
+    """
+    text = syntax.highlight(syntax.code)
+    new_spans = []
+    for span in text._spans:
+        style = span.style
+        if isinstance(style, RichStyle) and style.bgcolor:
+            style = RichStyle(color=style.color, bold=style.bold, italic=style.italic, underline=style.underline)
+            new_spans.append(RichSpan(span.start, span.end, style))
+        else:
+            new_spans.append(span)
+    text._spans = new_spans
+    if isinstance(text.style, RichStyle) and text.style.bgcolor:
+        text.style = RichStyle(
+            color=text.style.color, bold=text.style.bold, italic=text.style.italic, underline=text.style.underline
+        )
+    return Content.from_rich_text(text)
+
+
 # --- Collapsible box factory functions ---
 
 
@@ -245,7 +274,6 @@ def create_user_input_box(content: str, agent_id: str = "") -> Collapsible:
         Collapsible widget with the input text, expanded by default.
     """
     # Use plain text here so Textual's selection API can extract content.
-    # Static.get_selection() does not currently support Rich Syntax renderables.
     text = Static(content, markup=False)
     box = Collapsible(
         text,
@@ -294,8 +322,8 @@ def create_code_action_box(code: str, agent_id: str = "") -> tuple[Collapsible, 
     Returns:
         Tuple of the Collapsible widget and the nested trace container.
     """
-    syntax = Syntax(code, "python", theme="monokai", line_numbers=True)
-    content, trace_container = _wrap_with_trace_container(Static(syntax))
+    syntax = Syntax(code, "python", theme="monokai")
+    content, trace_container = _wrap_with_trace_container(Static(_syntax_to_content(syntax)))
     box = Collapsible(
         content,
         title=_titled("Code Action", agent_id),
@@ -325,7 +353,7 @@ def create_tool_call_box(
     args_json = json.dumps(tool_args, indent=2)
     syntax = Syntax(args_json, "json", theme="monokai")
     title_prefix = "PTC" if ptc else "Tool Call"
-    content, trace_container = _wrap_with_trace_container(Static(syntax))
+    content, trace_container = _wrap_with_trace_container(Static(_syntax_to_content(syntax)))
     box = Collapsible(
         content,
         title=_titled(f"{title_prefix}: {tool_name}", agent_id),
@@ -350,7 +378,7 @@ def create_subagent_task_box(
     """
     args_json = json.dumps(tool_args, indent=2)
     syntax = Syntax(args_json, "json", theme="monokai")
-    content, trace_container = _wrap_with_trace_container(Static(syntax))
+    content, trace_container = _wrap_with_trace_container(Static(_syntax_to_content(syntax)))
     box = Collapsible(
         content,
         title=_titled("Tool Call: subagent_task", agent_id),
@@ -374,19 +402,27 @@ def create_exec_output_box(agent_id: str = "") -> tuple[Collapsible, RichLog]:
     return box, log
 
 
-def finalize_exec_output(log: RichLog, text: str | None, images: list[Path]) -> None:
-    """Finalize a streaming execution log with terminal output and image paths.
+async def finalize_exec_output(log: RichLog, text: str | None, images: list[Path]) -> None:
+    """Replace a streaming RichLog with a selectable Static widget.
+
+    RichLog does not support Textual's native text selection. This swaps
+    it for a plain Static after streaming completes.
 
     Args:
-        log: Target log widget to update.
-        text: Final text output. When present, replaces streamed content.
-        images: Generated image paths to append to the log.
+        log: Streaming log widget to replace.
+        text: Final text output.
+        images: Generated image paths to append.
     """
+    parts: list[str] = []
     if text:
-        log.clear()
-        syntax = Syntax(text.rstrip("\n"), "text", theme="monokai", line_numbers=True)
-        log.write(syntax)
+        parts.append(text.rstrip("\n"))
     if images:
+        parts.append("Produced images:\n" + "\n".join(f"  {path}" for path in images))
+    if parts and log.parent is not None:
+        static = Static("\n".join(parts), markup=False)
+        await log.parent.mount(static, after=log)
+        await log.remove()
+    elif images:
         log.write("Produced images:\n" + "\n".join(f"  {path}" for path in images))
 
 
@@ -401,9 +437,9 @@ def create_tool_output_box(content: str, agent_id: str = "") -> Collapsible:
         Collapsible widget that displays truncated tool output.
     """
     display_content = content
-    syntax = Syntax(display_content, "text", theme="monokai", line_numbers=True)
+    syntax = Syntax(display_content, "text", theme="monokai")
     box = Collapsible(
-        Static(syntax),
+        Static(_syntax_to_content(syntax)),
         title=_titled("Tool Output", agent_id),
         collapsed=True,
         classes="tool-output-box",
@@ -487,8 +523,8 @@ def create_file_write_action_box(path: str, content: str, agent_id: str = "") ->
         Tuple of the Collapsible widget and the nested trace container.
     """
     ext = path.rsplit(".", 1)[-1] if "." in path else "text"
-    syntax = Syntax(content, ext, theme="monokai", line_numbers=True)
-    content_widget, trace_container = _wrap_with_trace_container(Static(syntax))
+    syntax = Syntax(content, ext, theme="monokai")
+    content_widget, trace_container = _wrap_with_trace_container(Static(_syntax_to_content(syntax)))
     box = Collapsible(
         content_widget,
         title=_titled(f"Write Action: {path}", agent_id),
@@ -528,7 +564,7 @@ def create_file_edit_action_box(
 
     diff_text = "\n".join(diff_lines)
     syntax = Syntax(diff_text, "diff", theme="monokai")
-    content, trace_container = _wrap_with_trace_container(Static(syntax))
+    content, trace_container = _wrap_with_trace_container(Static(_syntax_to_content(syntax)))
     box = Collapsible(
         content,
         title=_titled(f"Edit Action: {path}", agent_id),

--- a/tests/unit/terminal/test_app.py
+++ b/tests/unit/terminal/test_app.py
@@ -10,13 +10,14 @@ from textual.keys import Keys
 from textual.pilot import Pilot
 from textual.widgets import Static
 
-from freeact.agent.call import CodeAction, GenericCall, ShellAction, ToolCall
+from freeact.agent.call import CodeAction, FileEdit, FileWrite, GenericCall, ShellAction, TextEdit, ToolCall
 from freeact.agent.config.skills import SkillMetadata
 from freeact.agent.events import (
     AgentEvent,
     ApprovalRequest,
     Cancelled,
     CodeExecutionOutput,
+    CodeExecutionOutputChunk,
     Response,
     ResponseChunk,
     Thoughts,
@@ -359,6 +360,112 @@ async def test_user_input_box_text_is_selectable_and_copyable() -> None:
         await pilot.press("ctrl+c")
         assert app.clipboard == "copy me from user input"
         assert clipboard_adapter.copy_calls == ["copy me from user input"]
+
+
+@pytest.mark.asyncio
+async def test_mouse_drag_selects_text_in_all_widget_types() -> None:
+    """E2E: mouse drag selection works on all widget types."""
+    permission_manager = StubPermissionManager(preapproved=True)
+
+    async def scenario(_: PromptContent) -> AsyncIterator[AgentEvent]:
+        # Code action with exec output (streaming chunks then final)
+        code_req = ApprovalRequest(
+            tool_call=CodeAction(tool_name="ipybox_execute_ipython_cell", code="print('hello')"),
+            agent_id=MAIN_AGENT_ID,
+            corr_id="code-1",
+        )
+        yield code_req
+        if await code_req.approved():
+            yield CodeExecutionOutputChunk(text="hello\n", agent_id=MAIN_AGENT_ID, corr_id="code-1")
+            yield CodeExecutionOutput(
+                text="hello\n",
+                images=[],
+                truncated=False,
+                agent_id=MAIN_AGENT_ID,
+                corr_id="code-1",
+            )
+            yield ToolOutput(content="hello\n", agent_id=MAIN_AGENT_ID, corr_id="code-1")
+        # Tool call with output
+        tool_req = ApprovalRequest(
+            tool_call=GenericCall(tool_name="db_query", tool_args={"q": "SELECT 1"}, ptc=False),
+            agent_id=MAIN_AGENT_ID,
+            corr_id="call-1",
+        )
+        yield tool_req
+        if await tool_req.approved():
+            yield ToolOutput(content="result data", agent_id=MAIN_AGENT_ID, corr_id="call-1")
+        # File write
+        write_req = ApprovalRequest(
+            tool_call=FileWrite(tool_name="file_write", path="out.py", content="x = 1"),
+            agent_id=MAIN_AGENT_ID,
+            corr_id="write-1",
+        )
+        yield write_req
+        if await write_req.approved():
+            yield ToolOutput(content="ok", agent_id=MAIN_AGENT_ID, corr_id="write-1")
+        # File edit
+        edit_req = ApprovalRequest(
+            tool_call=FileEdit(
+                tool_name="file_edit",
+                path="out.py",
+                edits=(TextEdit(old_text="x = 1", new_text="x = 2"),),
+            ),
+            agent_id=MAIN_AGENT_ID,
+            corr_id="edit-1",
+        )
+        yield edit_req
+        if await edit_req.approved():
+            yield ToolOutput(content="ok", agent_id=MAIN_AGENT_ID, corr_id="edit-1")
+
+    config = TerminalConfig(
+        collapse_approved_code_actions=False,
+        collapse_exec_output_on_complete=False,
+        collapse_approved_tool_calls=False,
+        collapse_tool_outputs=False,
+    )
+    app = _create_app(
+        agent_stream=MockStreamAgent(scenario).stream,
+        agent_id=MAIN_AGENT_ID,
+        permission_manager=permission_manager,  # type: ignore[arg-type]
+        config=config,
+    )
+
+    async with app.run_test(size=(80, 80)) as pilot:
+        await _submit_prompt(app, pilot)
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        from textual.geometry import Offset
+
+        async def assert_drag(widget: Static, length: int, expected: str, label: str) -> None:
+            await pilot.mouse_down(widget, offset=Offset(0, 0))
+            await pilot.mouse_up(widget, offset=Offset(length, 0))
+            text = app.screen.get_selected_text()
+            assert text is not None and expected in text, f"{label}: {text!r}"
+            app.screen.clear_selection()
+
+        # Code action
+        code_w = app.query(".code-action-box .tool-call-content > Static").first()
+        await assert_drag(code_w, 14, "print", "code action")
+
+        # Exec output (RichLog replaced with Static)
+        exec_w = app.query(".exec-output-box Static").last()
+        assert isinstance(exec_w, Static)
+        await assert_drag(exec_w, 5, "hello", "exec output")
+
+        # Tool output (find the db_query tool call box, then its nested tool output)
+        db_query_boxes = [b for b in app.query(".tool-call-box") if "db_query" in b.title]
+        tool_w = db_query_boxes[0].query(".tool-output-box Contents > Static").first()
+        assert isinstance(tool_w, Static)
+        await assert_drag(tool_w, 11, "result data", "tool output")
+
+        # File write
+        write_w = app.query(".write-file-box .tool-call-content > Static").first()
+        await assert_drag(write_w, 5, "x = 1", "file write")
+
+        # File edit (diff)
+        edit_w = app.query(".diff-box .tool-call-content > Static").first()
+        await assert_drag(edit_w, 14, "--- a/out.py", "file edit")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/terminal/test_widgets.py
+++ b/tests/unit/terminal/test_widgets.py
@@ -1,10 +1,13 @@
+from rich.syntax import Syntax
 from textual.binding import Binding
+from textual.content import Content
 from textual.widgets import Static
 
 from freeact.agent.call import TextEdit
 from freeact.terminal.widgets import (
     ApprovalBar,
     PromptInput,
+    _syntax_to_content,
     create_code_action_box,
     create_error_box,
     create_file_edit_action_box,
@@ -178,3 +181,11 @@ def test_create_user_input_box_wraps_content() -> None:
     assert isinstance(static, Static)
     assert static.content == "long line"
     assert str(static.styles.text_wrap) == "wrap"
+
+
+def test_syntax_to_content_preserves_text_and_returns_content() -> None:
+    syntax = Syntax("print(42)", "python", theme="monokai")
+    content = _syntax_to_content(syntax)
+
+    assert isinstance(content, Content)
+    assert content.plain == "print(42)\n"


### PR DESCRIPTION
## Summary

- Convert `Syntax` renderables to `Content` via `_syntax_to_content()`, stripping token backgrounds so Textual's selection highlight applies uniformly
- Replace streaming `RichLog` with `Static` after exec output finalization, since `RichLog` bypasses Textual's Visual pipeline
- Remove `line_numbers=True` from all `Syntax` usage in widget factories

🤖 Generated with [Claude Code](https://claude.com/claude-code)