### PR TITLE
Show verbatim shell command in approval bar

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -106,10 +106,10 @@ Press `Escape` during an active agent turn to cancel it. This interrupts the cur
 
 ### Approval Prompt
 
-Before executing code actions, shell commands, and tool calls, the agent requests approval. Shell commands and programmatic tool calls within code actions are intercepted during execution and approved individually. The prompt displays a suggested pattern that summarizes the pending action:
+Before executing code actions, shell commands, and tool calls, the agent requests approval. Shell commands and programmatic tool calls within code actions are intercepted during execution and approved individually. For shell commands the prompt displays the verbatim command being executed; for other action types it displays a suggested permission pattern that summarizes the action:
 
 ```
-Approve? [Y/n/a/s] git add *
+Approve? [Y/n/a/s] git add src/main.py
 ```
 
 | Key | Action |
@@ -119,18 +119,19 @@ Approve? [Y/n/a/s] git add *
 | `a` | Edit pattern, then save as always-allow rule |
 | `s` | Edit pattern, then save as session-allow rule |
 
-Pressing `a` or `s` opens the pattern for inline editing. The input is pre-filled with the suggested pattern. Edit the pattern to broaden or narrow the rule (e.g. change `filesystem_read_file src/main.py` to `filesystem_* src/**`), then press `Enter` to save the rule and approve. While editing, approval hotkeys are disabled so you can type freely.
+Pressing `a` or `s` opens an editable input pre-filled with the suggested permission pattern (not the verbatim text shown above). Edit the pattern to broaden or narrow the rule (e.g. change `filesystem_read_file src/main.py` to `filesystem_* src/**`), then press `Enter` to save the rule and approve. While editing, approval hotkeys are disabled so you can type freely.
 
 Always-allow rules persist to `.freeact/permissions.json` across sessions. Session-allow rules are in-memory and cleared when the session ends. Future actions matching a saved rule are auto-approved without prompting.
 
-The suggested pattern depends on the action type:
+What the bar displays depends on the action type:
 
-| Action | Pattern format | Example |
-|--------|---------------|---------|
-| Shell command | `command *` heuristic | `git add *` |
-| Code action | tool name | `ipybox_execute_ipython_cell` |
-| File read/write/edit | tool name + path | `filesystem_write_text_file src/main.py` |
-| Other tool calls | tool name | `github_search_repositories` |
+| Action | Bar shows | Suggested pattern (when pressing `a`/`s`) |
+|--------|-----------|-------------------------------------------|
+| Shell command (`!cmd` and split sub-commands) | Verbatim command, e.g. `git add src/main.py` | `cmd subcmd *` heuristic, e.g. `git add *` |
+| Shell magic (`%%bash`) | First non-empty line + `(+N more lines)` summary; full script is shown in the Shell Script box above the bar | Full script with newlines escaped as `\n` |
+| Code action | Tool name, e.g. `ipybox_execute_ipython_cell` | Same |
+| File read/write/edit | Tool name + path, e.g. `filesystem_write_text_file src/main.py` | Same |
+| Other tool calls | Tool name, e.g. `github_search_repositories` | Same |
 
 See [Permissions](configuration.md#permissions) for the persisted format and pattern syntax.
 !!! hint "Automatic approval"

--- a/docs/internal/architecture/constraints/permissions.md
+++ b/docs/internal/architecture/constraints/permissions.md
@@ -1,17 +1,18 @@
 # Permission System Constraints
 
-The permission system uses methods on `ToolCall` subtypes for self-description. Each subtype implements four methods:
+The permission system uses methods on `ToolCall` subtypes for self-description. Each subtype implements five methods:
 
 | Method | Purpose |
 |---|---|
 | `to_pattern()` | Suggest editable pattern from ToolCall |
+| `to_display()` | Return verbatim text for the approval bar (empty string falls back to the pattern) |
 | `from_pattern(pattern)` | Reconstruct ToolCall from edited pattern |
 | `to_entry()` | Serialize ToolCall to permission dict |
 | `matches_entry(entry, working_dir)` | Check if a rule matches this concrete ToolCall |
 
-The base `ToolCall` class provides defaults (returns `tool_name` for pattern, `False` for matching). Subtypes override with type-specific logic.
+The base `ToolCall` class provides defaults (returns `tool_name` for pattern, `""` for display, `False` for matching). Subtypes override with type-specific logic. `ShellAction` overrides `to_display()` to surface the verbatim command (`bash`) or a first-line summary (`shell_magic`); other subtypes inherit the empty default so the bar shows the suggested pattern.
 
-Standalone functions `suggest_pattern()` and `parse_pattern()` in `freeact/agent/call.py` delegate to these methods and are kept for API stability.
+Standalone functions `suggest_pattern()`, `suggest_display()`, and `parse_pattern()` in `freeact/agent/call.py` delegate to these methods and are kept for API stability.
 
 `PermissionManager` in `freeact/permissions.py` calls `tool_call.to_entry()` and `tool_call.matches_entry()` directly, importing only the `ToolCall` base class.
 
@@ -24,5 +25,5 @@ When adding a new ToolCall subtype, three places must be updated:
 | Location | Purpose |
 |---|---|
 | `ToolCall.from_raw()` in `freeact/agent/call.py` | Map raw tool name to subtype |
-| Methods on the new subtype in `freeact/agent/call.py` | `to_pattern`, `from_pattern`, `to_entry`, `matches_entry` |
+| Methods on the new subtype in `freeact/agent/call.py` | `to_pattern`, `to_display` (optional override), `from_pattern`, `to_entry`, `matches_entry` |
 | Widget dispatch in `freeact/terminal/app.py` | Route to UI factory |

--- a/docs/internal/architecture/runtime.md
+++ b/docs/internal/architecture/runtime.md
@@ -5,7 +5,7 @@ It intentionally excludes CLI, terminal UI, and longer-lived permission policy l
 
 ## Core Agent
 
-- `freeact/agent/call.py` defines the `ToolCall` type hierarchy (`GenericCall`, `ShellAction`, `CodeAction`, `FileRead`, `FileWrite`, `FileEdit`), pattern functions (`suggest_pattern`, `parse_pattern`), and `extract_tool_output_text`. Filesystem tool names: `filesystem_read_text_file`, `filesystem_read_media_file`, `filesystem_write_text_file`, `filesystem_edit_text_file`.
+- `freeact/agent/call.py` defines the `ToolCall` type hierarchy (`GenericCall`, `ShellAction`, `CodeAction`, `FileRead`, `FileWrite`, `FileEdit`), pattern functions (`suggest_pattern`, `suggest_display`, `parse_pattern`), and `extract_tool_output_text`. Filesystem tool names: `filesystem_read_text_file`, `filesystem_read_media_file`, `filesystem_write_text_file`, `filesystem_edit_text_file`.
 - `freeact/agent/events.py` defines all typed stream events (`ResponseChunk`, `Response`, `Thoughts*`, `ApprovalRequest`, `CodeExecutionOutput*`, `ToolOutput`).
 - `freeact/agent/core.py` contains the `Agent` class and main orchestration loop.
 - `freeact/agent/_supervisor.py` contains `_ResourceSupervisor`, a generic async lifecycle utility for context managers.

--- a/docs/internal/architecture/terminal.md
+++ b/docs/internal/architecture/terminal.md
@@ -36,9 +36,9 @@ Read this first, then follow code references for details.
 
 - `clipboard.py`: platform clipboard adapter (`pbcopy/pbpaste`, `wl-*`, `xclip`/`xsel`, PowerShell) with local fallback.
 - `config.py`: terminal UI collapse behavior and keybinding configuration.
-- `widgets.py`: all prompt/approval widgets and box factories (including `ApprovalBar` with inline pattern editing).
+- `widgets.py`: all prompt/approval widgets and box factories. `ApprovalBar` takes a `pattern` (seeds the inline edit input on `a`/`s`) and an optional `display_text` (the verbatim text shown in the bar; falls back to `pattern` when empty). The attribute is named `display_text` to avoid shadowing Textual's `Widget.display` reactive.
 - `screens.py`: modal file picker for `@` insertion.
-- `freeact/agent/call.py`: `ToolCall` type hierarchy, `suggest_pattern`, `parse_pattern`, `extract_tool_output_text`.
+- `freeact/agent/call.py`: `ToolCall` type hierarchy, `suggest_pattern`, `suggest_display`, `parse_pattern`, `extract_tool_output_text`.
 - `freeact.permissions.PermissionManager`: pre-approval and persisted/session allow-lists.
 
 ## Keyboard Semantics

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -293,3 +293,5 @@ async for event in agent.stream(prompt):
                     case _:
                         request.approve(True)
 ```
+
+For shell commands, [`suggest_display(tool_call)`][freeact.agent.suggest_display] returns the verbatim command (or a first-line summary for `%%bash` shell magic) and is suitable for displaying in the prompt instead of the permission pattern. It returns an empty string for non-shell tool calls, so applications can fall back to `suggest_pattern()` in that case.

--- a/freeact/agent/__init__.py
+++ b/freeact/agent/__init__.py
@@ -8,6 +8,7 @@ from freeact.agent.call import (
     ToolCall,
     extract_tool_output_text,
     parse_pattern,
+    suggest_display,
     suggest_pattern,
 )
 from freeact.agent.core import Agent
@@ -45,5 +46,6 @@ __all__ = [
     "ToolOutput",
     "extract_tool_output_text",
     "parse_pattern",
+    "suggest_display",
     "suggest_pattern",
 ]

--- a/freeact/agent/call.py
+++ b/freeact/agent/call.py
@@ -81,6 +81,15 @@ class ToolCall:
         """Suggest a permission pattern string for this tool call."""
         return self.tool_name
 
+    def to_display(self) -> str:
+        """Return display text for the approval bar.
+
+        Empty string means "fall back to the suggested pattern". Subclasses
+        override this to surface the verbatim action being approved (e.g. a
+        shell command) instead of the permission pattern.
+        """
+        return ""
+
     def from_pattern(self, pattern: str) -> "ToolCall":
         """Reconstruct a ToolCall from a user-edited pattern string."""
         return GenericCall(tool_name=pattern, tool_args={}, ptc=False)
@@ -120,6 +129,11 @@ class ShellAction(ToolCall):
         if self.tool_name == "shell_magic":
             return self.command.replace("\n", "\\n")
         return suggest_shell_pattern(self.command)
+
+    def to_display(self) -> str:
+        if self.tool_name == "shell_magic":
+            return _summarize_shell_script(self.command)
+        return self.command
 
     def from_pattern(self, pattern: str) -> "ToolCall":
         command = pattern.replace("\\n", "\n") if self.tool_name == "shell_magic" else pattern
@@ -251,6 +265,36 @@ def suggest_pattern(tool_call: ToolCall) -> str:
         Pattern string suitable for the approval bar.
     """
     return tool_call.to_pattern()
+
+
+def suggest_display(tool_call: ToolCall) -> str:
+    """Suggest display text for the approval bar for a tool call.
+
+    Args:
+        tool_call: The tool call to render in the approval bar.
+
+    Returns:
+        Display string for the approval bar, or an empty string when the
+        bar should fall back to the suggested permission pattern.
+    """
+    return tool_call.to_display()
+
+
+def _summarize_shell_script(script: str) -> str:
+    """Render a multi-line shell script as a compact single-line summary.
+
+    Returns the first non-empty line, optionally followed by a count of
+    the remaining non-empty lines. Used by the approval bar so the bar
+    stays compact while the full script is shown in the action box above.
+    """
+    lines = [line for line in script.splitlines() if line.strip()]
+    if not lines:
+        return "(empty script)"
+    head = lines[0].strip()
+    extra = len(lines) - 1
+    if extra == 0:
+        return head
+    return f"{head} (+{extra} more lines)"
 
 
 def parse_pattern(pattern: str, template: ToolCall) -> ToolCall:

--- a/freeact/terminal/app.py
+++ b/freeact/terminal/app.py
@@ -27,6 +27,7 @@ from freeact.agent.call import (
     ToolCall,
     extract_tool_output_text,
     parse_pattern,
+    suggest_display,
     suggest_pattern,
 )
 from freeact.agent.config.skills import SkillMetadata
@@ -882,7 +883,7 @@ class TerminalApp(App[None]):
 
         # Prompt user for approval
         self._approval_future = asyncio.get_running_loop().create_future()
-        bar = ApprovalBar(pattern=suggested)
+        bar = ApprovalBar(pattern=suggested, display_text=suggest_display(tc))
         await self._mount_and_scroll(conversation, conversation, bar)
 
         decision, pattern = await self._approval_future

--- a/freeact/terminal/widgets.py
+++ b/freeact/terminal/widgets.py
@@ -153,15 +153,17 @@ class ApprovalBar(Static):
         ("s", "save_rule(3)", "Session"),
     ]
 
-    def __init__(self, pattern: str = "", **kwargs: Any) -> None:
+    def __init__(self, pattern: str = "", display_text: str = "", **kwargs: Any) -> None:
         self._pattern = pattern
+        self._display_text = display_text
         self._editing = False
         self._pending_decision: int = 0
         super().__init__(self._render_text(), markup=False, **kwargs)
 
     def _render_text(self) -> str:
-        if self._pattern:
-            return f"Approve? [Y/n/a/s] {self._pattern}"
+        body = self._display_text or self._pattern
+        if body:
+            return f"Approve? [Y/n/a/s] {body}"
         return "Approve? [Y/n/a/s]"
 
     def action_decide(self, decision: int) -> None:
@@ -194,6 +196,15 @@ class ApprovalBar(Static):
     def pattern(self) -> str:
         """Current pattern value."""
         return self._pattern
+
+    @property
+    def display_text(self) -> str:
+        """Current display text override (empty string falls back to pattern).
+
+        Named to avoid clashing with the inherited Textual `Widget.display`
+        reactive (which controls visibility).
+        """
+        return self._display_text
 
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
         if self._editing and action in ("decide", "save_rule"):

--- a/tests/unit/terminal/test_app.py
+++ b/tests/unit/terminal/test_app.py
@@ -1475,6 +1475,109 @@ async def test_shell_approval_request_routes_to_shell_domain() -> None:
 
 
 @pytest.mark.asyncio
+async def test_shell_approval_bar_displays_verbatim_command_for_bash() -> None:
+    async def scenario(_: PromptContent) -> AsyncIterator[AgentEvent]:
+        request = ApprovalRequest(
+            tool_call=ShellAction(tool_name="bash", command="git status"),
+            agent_id=MAIN_AGENT_ID,
+            corr_id="call-1",
+        )
+        yield request
+        await request.approved()
+
+    app = _create_app(
+        agent_stream=MockStreamAgent(scenario).stream,
+        agent_id=MAIN_AGENT_ID,
+        permission_manager=StubPermissionManager(),  # type: ignore[arg-type]
+    )
+
+    async with app.run_test() as pilot:
+        await _submit_prompt(app, pilot)
+        await pilot.pause(0.05)
+
+        bars = list(app.query("ApprovalBar"))
+        assert len(bars) == 1
+        text = str(bars[0].content)
+        assert "git status" in text
+        assert "git status *" not in text
+
+        await pilot.press("n")
+        await app.workers.wait_for_complete()
+
+
+@pytest.mark.asyncio
+async def test_shell_approval_bar_summarizes_shell_magic_script() -> None:
+    script = "echo first\necho second\necho third"
+
+    async def scenario(_: PromptContent) -> AsyncIterator[AgentEvent]:
+        request = ApprovalRequest(
+            tool_call=ShellAction(tool_name="shell_magic", command=script),
+            agent_id=MAIN_AGENT_ID,
+            corr_id="call-1",
+        )
+        yield request
+        await request.approved()
+
+    app = _create_app(
+        agent_stream=MockStreamAgent(scenario).stream,
+        agent_id=MAIN_AGENT_ID,
+        permission_manager=StubPermissionManager(),  # type: ignore[arg-type]
+    )
+
+    async with app.run_test() as pilot:
+        await _submit_prompt(app, pilot)
+        await pilot.pause(0.05)
+
+        bars = list(app.query("ApprovalBar"))
+        text = str(bars[0].content)
+        assert "echo first" in text
+        assert "+2 more" in text
+        assert "\\n" not in text
+        assert "echo first\\necho second" not in text
+
+        await pilot.press("n")
+        await app.workers.wait_for_complete()
+
+
+@pytest.mark.asyncio
+async def test_shell_approval_a_seeds_input_with_suggested_pattern() -> None:
+    from textual.widgets import Input
+
+    permission_manager = StubPermissionManager()
+
+    async def scenario(_: PromptContent) -> AsyncIterator[AgentEvent]:
+        request = ApprovalRequest(
+            tool_call=ShellAction(tool_name="bash", command="git status"),
+            agent_id=MAIN_AGENT_ID,
+            corr_id="call-1",
+        )
+        yield request
+        await request.approved()
+
+    app = _create_app(
+        agent_stream=MockStreamAgent(scenario).stream,
+        agent_id=MAIN_AGENT_ID,
+        permission_manager=permission_manager,  # type: ignore[arg-type]
+    )
+
+    async with app.run_test() as pilot:
+        await _submit_prompt(app, pilot)
+        await pilot.pause(0.05)
+        await pilot.press("a")
+        await pilot.pause(0.05)
+
+        input_widget = app.query_one("#approval-pattern-input", Input)
+        assert input_widget.value == "git status *"
+
+        await pilot.press("enter")
+        await app.workers.wait_for_complete()
+
+    assert len(permission_manager.allow_always_calls) == 1
+    assert isinstance(permission_manager.allow_always_calls[0], ShellAction)
+    assert permission_manager.allow_always_calls[0].command == "git status *"
+
+
+@pytest.mark.asyncio
 async def test_shell_approval_uses_suggest_shell_pattern() -> None:
     permission_manager = StubPermissionManager()
 

--- a/tests/unit/terminal/test_widgets.py
+++ b/tests/unit/terminal/test_widgets.py
@@ -140,6 +140,38 @@ def test_approval_bar_default_pattern_is_empty() -> None:
     assert bar.pattern == ""
 
 
+def test_approval_bar_display_text_overrides_pattern() -> None:
+    bar = ApprovalBar(pattern="git *", display_text="git status")
+    content = str(bar.content)
+    assert "git status" in content
+    assert "git *" not in content
+    assert content.startswith("Approve? [Y/n/a/s] ")
+
+
+def test_approval_bar_falls_back_to_pattern_when_no_display_text() -> None:
+    bar = ApprovalBar(pattern="github_*")
+    content = str(bar.content)
+    assert "github_*" in content
+
+
+def test_approval_bar_display_text_property_round_trip() -> None:
+    bar = ApprovalBar(display_text="echo hi")
+    assert bar.display_text == "echo hi"
+    assert bar.pattern == ""
+
+
+def test_approval_bar_does_not_shadow_widget_display_reactive() -> None:
+    """Regression: ApprovalBar must not shadow Textual's `Widget.display`
+    reactive (which is a bool controlling visibility). Shadowing it with a
+    string property hides the bar in the running app even though the unit
+    tests for content/query still pass.
+    """
+    bar = ApprovalBar(pattern="cmd")
+    assert bar.display is True
+    bar_with_text = ApprovalBar(pattern="cmd", display_text="echo hi")
+    assert bar_with_text.display is True
+
+
 def test_prompt_input_css_uses_solid_border_variants() -> None:
     css = PromptInput.DEFAULT_CSS
     assert "border: solid $border-blurred;" in css


### PR DESCRIPTION
The approval bar now displays the verbatim shell command (or first-line
summary for `%%bash` shell magic) instead of the suggested permission
pattern. The pattern is still pre-filled into the editable input when
the user presses `a` or `s` to save a rule.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
