### PR TITLE
Replace live httpbin.org fetch tests with local HTTP server fixture

### DIFF
--- a/tests/integration/tools/http_server.py
+++ b/tests/integration/tools/http_server.py
@@ -1,0 +1,59 @@
+import asyncio
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, RedirectResponse, Response
+from starlette.routing import Route
+
+HTTP_SERVER_HOST = "127.0.0.1"
+HTTP_SERVER_PORT = 8712
+
+_JSON_PAYLOAD = {
+    "slideshow": {
+        "author": "freeact",
+        "title": "Sample Slide Show",
+        "slides": [
+            {"title": "Wake up to freeact", "type": "all"},
+            {"title": "Overview", "type": "all", "items": ["Why freeact is great", "Who freeact is for"]},
+        ],
+    }
+}
+
+
+async def _json_endpoint(request: Request) -> Response:
+    return JSONResponse(_JSON_PAYLOAD)
+
+
+async def _redirect_endpoint(request: Request) -> Response:
+    return RedirectResponse(url="/json")
+
+
+def create_app() -> Starlette:
+    return Starlette(
+        routes=[
+            Route("/json", _json_endpoint),
+            Route("/redirect/1", _redirect_endpoint),
+        ]
+    )
+
+
+@asynccontextmanager
+async def local_http_server(
+    host: str = HTTP_SERVER_HOST,
+    port: int = HTTP_SERVER_PORT,
+) -> AsyncIterator[str]:
+    import uvicorn
+
+    cfg = uvicorn.Config(create_app(), host=host, port=port, log_level="error")
+    server = uvicorn.Server(cfg)
+    task = asyncio.create_task(server.serve())
+    while not server.started:
+        await asyncio.sleep(0.01)
+
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        server.should_exit = True
+        await task

--- a/tests/integration/tools/test_fetch.py
+++ b/tests/integration/tools/test_fetch.py
@@ -1,8 +1,18 @@
 import json
+from typing import AsyncIterator
 
 import pytest
+import pytest_asyncio
 
 from freeact.tools.fetch import web_fetch
+from tests.integration.tools.http_server import local_http_server
+
+
+@pytest_asyncio.fixture
+async def http_server() -> AsyncIterator[str]:
+    """Local HTTP server serving deterministic /json and /redirect/1 endpoints."""
+    async with local_http_server() as base_url:
+        yield base_url
 
 
 @pytest.mark.asyncio
@@ -38,9 +48,9 @@ async def test_falls_back_to_plain_on_index_page() -> None:
 
 
 @pytest.mark.asyncio
-async def test_fetches_json_endpoint() -> None:
+async def test_fetches_json_endpoint(http_server: str) -> None:
     """JSON endpoints should be pretty-printed."""
-    result = await web_fetch("https://httpbin.org/json")
+    result = await web_fetch(f"{http_server}/json")
     parsed = json.loads(result)
 
     assert parsed["status"] == 200
@@ -49,9 +59,9 @@ async def test_fetches_json_endpoint() -> None:
 
 
 @pytest.mark.asyncio
-async def test_follows_redirects() -> None:
+async def test_follows_redirects(http_server: str) -> None:
     """Redirects should be followed, with finalUrl reflecting the destination."""
-    result = await web_fetch("https://httpbin.org/redirect/1")
+    result = await web_fetch(f"{http_server}/redirect/1")
     parsed = json.loads(result)
 
     assert parsed["status"] == 200


### PR DESCRIPTION
## Problem

The fetch integration tests reached out to the live external service `httpbin.org`, which intermittently returns 5xx (502/503) or times out. When httpbin is degraded, `test_fetches_json_endpoint` and `test_follows_redirects` fail even though nothing in the codebase is broken, so CI on `main` was hostage to a third party's uptime (#96).

## Change (test-only)

Implements the recommended fix from #96:

- Add `tests/integration/tools/http_server.py`, a deterministic local `uvicorn`/Starlette server fixture modelled on the existing `tests/integration/mcp_server.py`. It serves `/json` (an `application/json` response) and `/redirect/1` (a redirect to `/json`).
- Point `test_fetches_json_endpoint` and `test_follows_redirects` at this local server via a new `http_server` fixture instead of `https://httpbin.org/...`.

The real `web_fetch` JSON-extraction and redirect-following logic is still exercised end to end, now fully deterministic and with no external network dependency.

No production code changes.

Closes #96