### PR TITLE
Upgrade default model to Gemini 3.6 Flash

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -69,7 +69,7 @@ The core install covers everything else: SDK, CLI, bundled tool servers, and bas
 
 ## API Key
 
-Freeact uses `google-gla:gemini-3.5-flash` as the [default model](../guides/models.md). Set the API key in your environment:
+Freeact uses `google-gla:gemini-3.6-flash` as the [default model](../guides/models.md). Set the API key in your environment:
 
 ```bash
 export GEMINI_API_KEY="your-api-key"

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -16,7 +16,7 @@ See [Installation](installation.md) for alternative setup options and sandbox mo
 
 !!! tip "Using a different model"
 
-    The current default model is `google-gla:gemini-3.5-flash`. Freeact supports any model compatible with Pydantic AI. To switch providers or configure model settings, see [Configure models](../guides/models.md).
+    The current default model is `google-gla:gemini-3.6-flash`. Freeact supports any model compatible with Pydantic AI. To switch providers or configure model settings, see [Configure models](../guides/models.md).
 
 ## 2. Enable tools
 

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -14,8 +14,8 @@ The `model` field uses Pydantic AI's `provider:model-name` format. Common provid
 
 | Provider | Prefix | Example |
 |----------|--------|---------|
-| Google (Gemini API) | `google-gla:` | `google-gla:gemini-3.5-flash` |
-| Google (Vertex AI) | `google-vertex:` | `google-vertex:gemini-3.5-flash` |
+| Google (Gemini API) | `google-gla:` | `google-gla:gemini-3.6-flash` |
+| Google (Vertex AI) | `google-vertex:` | `google-vertex:gemini-3.6-flash` |
 | Anthropic | `anthropic:` | `anthropic:claude-sonnet-4-6` |
 | OpenAI | `openai:` | `openai:gpt-5.2` |
 | OpenRouter | `openrouter:` | `openrouter:anthropic/claude-sonnet-4.6` |
@@ -30,7 +30,7 @@ The default configuration uses Google's Gemini API with medium thinking enabled:
 
 ```toml
 [agent]
-model = "google-gla:gemini-3.5-flash"
+model = "google-gla:gemini-3.6-flash"
 
 [agent.model_settings]
 google_thinking_config = { thinking_level = "medium", include_thoughts = true }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -51,7 +51,7 @@ Freeact stores configuration and runtime state in `.freeact/`. Project-level cus
 
 ```toml title=".freeact/config.toml"
 [agent]
-model = "google-gla:gemini-3.5-flash"
+model = "google-gla:gemini-3.6-flash"
 # execution_timeout = 300.0     # seconds; 0 disables the timeout
 # approval_timeout = 0.0        # seconds; 0 waits forever
 # enable_persistence = true
@@ -109,7 +109,7 @@ The `[agent]` section accepts these keys:
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `model` | `google-gla:gemini-3.5-flash` | [Model identifier](../guides/models.md#model-identifier) in `provider:model-name` format |
+| `model` | `google-gla:gemini-3.6-flash` | [Model identifier](../guides/models.md#model-identifier) in `provider:model-name` format |
 | `model_settings` | [Google thinking config](../guides/models.md#google-default) | Provider-specific [model settings](../guides/models.md#model-settings) (e.g., thinking config, temperature) |
 | `provider_settings` | unset | Custom API credentials, endpoints, or other [provider-specific options](../guides/models.md#provider-settings) |
 | `tools` | `discovery = "basic"`, web tools off | Presets for [bundled tool servers](../guides/tool-servers.md#enable-bundled-servers) and [tool discovery](../guides/tool-discovery.md) |

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -4,7 +4,7 @@
 
 | Variable | Used by |
 |----------|---------|
-| `GEMINI_API_KEY` | The [default model](../guides/models.md#google-default) `google-gla:gemini-3.5-flash`, the bundled `google` search server ([`search` preset](../guides/tool-servers.md#enable-bundled-servers)), and the default [hybrid search](#hybrid-search) embedding model |
+| `GEMINI_API_KEY` | The [default model](../guides/models.md#google-default) `google-gla:gemini-3.6-flash`, the bundled `google` search server ([`search` preset](../guides/tool-servers.md#enable-bundled-servers)), and the default [hybrid search](#hybrid-search) embedding model |
 | `ANTHROPIC_API_KEY` | [Anthropic models](../guides/models.md#anthropic) (`anthropic:` prefix) |
 | `OPENAI_API_KEY` | [OpenAI models](../guides/models.md#openai) (`openai:` prefix) |
 | `BRAVE_API_KEY` | The bundled [`brave` search server](../guides/tool-servers.md#enable-bundled-servers) |

--- a/freeact/config/load.py
+++ b/freeact/config/load.py
@@ -14,7 +14,7 @@ DEFAULT_CONFIG_TOML = """\
 # this file, so comments and formatting are yours to keep.
 
 [agent]
-model = "google-gla:gemini-3.5-flash"
+model = "google-gla:gemini-3.6-flash"
 # execution_timeout = 300.0     # seconds; 0 disables the timeout
 # approval_timeout = 0.0        # seconds; 0 waits forever
 # enable_persistence = true

--- a/freeact/config/schema.py
+++ b/freeact/config/schema.py
@@ -4,7 +4,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-DEFAULT_MODEL_NAME = "google-gla:gemini-3.5-flash"
+DEFAULT_MODEL_NAME = "google-gla:gemini-3.6-flash"
 DEFAULT_MODEL_SETTINGS: dict[str, Any] = {
     "google_thinking_config": {
         "thinking_level": "medium",

--- a/freeact/tools/gsearch.py
+++ b/freeact/tools/gsearch.py
@@ -51,7 +51,7 @@ async def web_search(
     )
 
     response = await client.aio.models.generate_content(
-        model="gemini-3.5-flash",
+        model="gemini-3.6-flash",
         contents=query,
         config=config,
     )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -19,7 +19,7 @@ class TestSchemaDefaults:
     def test_agent_defaults(self) -> None:
         config = FreeactConfig()
 
-        assert config.agent.model == "google-gla:gemini-3.5-flash"
+        assert config.agent.model == "google-gla:gemini-3.6-flash"
         assert config.agent.model_settings["google_thinking_config"]["thinking_level"] == "medium"
         assert config.agent.execution_timeout == 300
         assert config.agent.approval_timeout == 0
@@ -210,7 +210,7 @@ class TestResolve:
         runtime = resolve(config, working_dir=tmp_path, env={})
 
         assert set(runtime.mcp_servers.keys()) == {"filesystem"}
-        assert runtime.model == "google-gla:gemini-3.5-flash"
+        assert runtime.model == "google-gla:gemini-3.6-flash"
         assert runtime.enable_subagents is True
         assert runtime.subagent_mode is False
 


### PR DESCRIPTION
Moves the default model from `gemini-3.5-flash` to `gemini-3.6-flash`.

## Model

Verified against the live API via `client.models.list()`:

```
models/gemini-3.6-flash | Gemini 3.6 Flash | 3.6-flash-07-2026
models/gemini-3.5-flash | Gemini 3.5 Flash | 3.5-flash-05-2026
```

These are distinct entries, not aliases. Note the id has no `-preview` suffix.

## Changes

13 replacements across 9 files: `DEFAULT_MODEL_NAME` in `config/schema.py`, the default TOML template in `config/load.py`, the grounded search call in `tools/gsearch.py`, two assertions in `tests/unit/test_config.py`, and five docs pages.

`gemini-embedding-001` is deliberately untouched — it is the embedding model, unrelated to the agent default, and still present in all 7 of its original locations (`tools/pytools/hybrid/embed.py`, `tools/pytools/hybrid/server.py`, `config/resolve.py` and tests).

## Dependencies

No changes. The `pydantic-ai>=1.99.0,<2` cap added in d4fc2ab is intact and effective: `uv lock --upgrade --dry-run` tops out at pydantic-ai 1.107.1 and google-genai 2.13.0, with nothing reaching 2.x despite pydantic-ai 2.15.0 being on the index. `uv.lock` is unchanged.

`thinking_budget` does not appear anywhere in the repo — it already uses `thinking_level` throughout, so the Gemini 3.x rejection of `thinking_budget: 0` does not apply.

## Verification

`invoke cc` clean. `invoke test --parallel`: **786 passed, 2 skipped**.

Beyond the suite, a real end-to-end interaction was run through the TUI on the new default. The agent was asked to compute the 30th Fibonacci number and the SHA-256 hex digest of the string `"gemini-3.6-flash"`. It emitted a thinking block (confirming `include_thoughts` streaming works on 3.6), generated a genuine `hashlib` + Fibonacci code action, passed the approval gate, and executed it in the ipybox kernel:

- F₃₀ = `832040`
- SHA-256 = `cf27b68ecf3890286c2922bbe05c9858f24b71c8e015dedb126e9a99c573d8be`

Both were recomputed independently in plain Python and match exactly, confirming the kernel really executed the code rather than the model producing a plausible digest. The session log contains 6 occurrences of `gemini-3.6-flash` and none of `gemini-3.5-flash`.

`web_search()` was also exercised live on 3.6 with the grounding tool at `thinking_level="medium"` — that is the path where a Gemini 3.x config rejection would surface, and it returned cleanly.